### PR TITLE
Update of registration Callback using the .register(this, SENDER_ID);…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Push.with(session)
 		@Override
 		public void onSuccess(Object result) {
 			System.out.println("Device was registered!");
+			registrationId = jsonObject.getString("token");
 		}
 
 	})
@@ -67,10 +68,10 @@ Push.with(session)
 		}
 
 	})
-	.register(registrationId);
+	.register(this, SENDER_ID);
 ```
 
-The `onSuccess` and `onFailure` callbacks are optional, but it's good practice to implement both. By doing so, your app can persist the device token or tell the user that an error occurred.
+The `onSuccess` and `onFailure` callbacks are optional, but it's good practice to implement both. By doing so, your app can persist the registrationId device token or tell the user that an error occurred.
 
 *Liferay Push for Android* is calling the *GCM server*, retrieving the results and storing your `registrationId` in the Liferay Portal instance for later use. If you obtain the token manually, you can register the device to the portal by calling the following method:
 


### PR DESCRIPTION
… method

In the registration device section, initially is reported the registration using the method with context and SENDER_ID parameters.

Push.with(session).register(this, SENDER_ID);

Right after (where async callback is explained) is used the other one version where the register is invoked (passing the registrationId parameter). It's not immediate understand that registrationId parameter is returned from a previous (or manual) registeration.
