### PR TITLE
Change to only import gcm and update version to latest reachable in play-services repo

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ apply from: 'https://raw.githubusercontent.com/brunofarache/liferay-mobile-sdk/m
 format.workingDir = 'src'
 
 dependencies {
-	compile group: 'com.google.android.gms', name: 'play-services', version: '6.5.87'
+	compile group: 'com.google.android.gms', name: 'play-services-gcm', version: '7.0.0'
 	compile group: 'com.liferay.mobile', name: 'liferay-android-sdk', version: '2.0.2'
 	compile group: 'com.squareup', name: 'otto', version: '1.3.6'
 


### PR DESCRIPTION
We're getting problems because of the dex limit of max methods and since 6.5.99 you can select just the module of play services you need, in this case gcm.

I had to update to 7.0.0 because the previous version is hard to download.
