### PR TITLE
Unsubscribe method to be able to close the bus

### DIFF
--- a/library/src/main/java/com/liferay/mobile/push/Push.java
+++ b/library/src/main/java/com/liferay/mobile/push/Push.java
@@ -108,6 +108,10 @@ public class Push {
 		getService().deletePushNotificationsDevice(registrationId);
 	}
 
+	public void unsubscribe() {
+		_subscriber.unsubscribe();
+	}
+
 	public Push withPortalVersion(int portalVersion) {
 		_portalVersion = portalVersion;
 		return this;


### PR DESCRIPTION
This is not ideal... the good way would be decoupling the bus with registering.

But right now we have a problem/leak with users registering (or listening to a notification in an activity) and changing to another activity because the bus is not closed.