### PR TITLE
Minor changes to create Liferay Push for Xamarin (Android)

### DIFF
--- a/library/src/main/java/com/liferay/mobile/push/bus/BusUtil.java
+++ b/library/src/main/java/com/liferay/mobile/push/bus/BusUtil.java
@@ -28,6 +28,10 @@ public class BusUtil {
 		getInstance().post(event);
 	}
 
+	public static void post(Exception e) {
+		getInstance().post(e);
+	}
+
 	public static void subscribe(Object object) {
 		getInstance().register(object);
 	}


### PR DESCRIPTION
* `Exception` cannot be cast to `Object` in Xamarin: we can't use BusUtil.post(Object) to send exceptions because Xamarin is not capable of convert `Exception` to `Object` and for that reason I created another `post` method with `Exception` parameter.